### PR TITLE
docs: make setRowSelectionState optional.

### DIFF
--- a/src/ExampleExtended.tsx
+++ b/src/ExampleExtended.tsx
@@ -148,7 +148,7 @@ const Example = () => {
     isEnabled: memoMode === "rows" || memoMode === "table-body",
     gridId,
     rowSelectionState: { ...rowSelectionState }, // use the spread operator to trigger re-render
-    setRowSelectionState: setRowSelectionState,
+    setRowSelectionState: setRowSelectionState, // Passing this prop could cause app error...
     colorPathChecked: theme.palette.primary.main, // theme.palette.action.active,
     colorPathBlank: theme.palette.action.active, // theme.palette.action.disabled,
     rowsGroupedRowModel: table.getGroupedRowModel() as MRT_RowModel<TableData>

--- a/src/ExampleMinimal.tsx
+++ b/src/ExampleMinimal.tsx
@@ -50,7 +50,7 @@ const Example = () => {
     isEnabled: memoMode === "rows" || memoMode === "table-body",
     gridId,
     rowSelectionState: { ...rowSelectionState }, // use the spread operator to trigger re-render
-    setRowSelectionState: setRowSelectionState,
+    setRowSelectionState: setRowSelectionState, // Passing this prop could cause app error...
     colorPathChecked: theme.palette.primary.main, // theme.palette.action.active,
     colorPathBlank: theme.palette.action.active, // theme.palette.action.disabled,
     rowsGroupedRowModel: table.getGroupedRowModel() as MRT_RowModel<TableData>

--- a/src/hooks/useMrtMemoModeRowsSelectionWorkaround.ts
+++ b/src/hooks/useMrtMemoModeRowsSelectionWorkaround.ts
@@ -20,7 +20,7 @@ interface useMrtMemoModeRowsSelectionWorkaroundProps<
 > {
   gridId: string;
   rowSelectionState: MRT_RowSelectionState; // pass a copy to this prop { ...rowSelectionState }
-  setRowSelectionState: (newState: MRT_RowSelectionState) => void;
+  setRowSelectionState?: (newState: MRT_RowSelectionState) => void; // This could be dangerous and you may need to implement it in a different way
   isEnabled: boolean;
   rowsGroupedRowModel: MRT_RowModel<TableData>;
   selectedRowClassName?: string;
@@ -240,7 +240,8 @@ export function useMrtMemoModeRowsSelectionWorkaround<
       });
 
       // Handle remove empty groups from the state
-      if (shouldUpdateTheState) {
+      if (shouldUpdateTheState && setRowSelectionState) {
+        // This could be dangerous and you may need to implement it in a different way
         setRowSelectionState(rowSelectionState); // setRowSelectionState(newRowSelectionState);
       }
     } catch (error) {


### PR DESCRIPTION
Make `setRowSelectionState` optional. It could be dangerous and you may need to implement it in a different way. 

We may need this in order to clear the column group IDs from the state before making server request. However we must do that before the request itself. If the row IDs are generated manually passing this prop to the hook most likely will break the app.